### PR TITLE
added error string format for rust

### DIFF
--- a/syntax_checkers/literate/lit.vim
+++ b/syntax_checkers/literate/lit.vim
@@ -12,7 +12,8 @@ function! SyntaxCheckers_literate_lit_GetLocList() dict
     let errorformat =
         \ '%f:%l:%trror: %m,' .
         \ '%f:%l:%tarning: %m,' .
-        \ '%f:%l: %m,'
+        \ '%f:%l: %m,' .
+        \ '%f:%l:%m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
Fair enough to show get linting for literate rust with syntastic