### PR TITLE
Allow autoindenting in the embedded language

### DIFF
--- a/indent/literate.vim
+++ b/indent/literate.vim
@@ -1,4 +1,3 @@
-finish
 if exists("b:did_indent")
 	finish
 endif


### PR DESCRIPTION
Currently, when working in a code block in vim, hitting Enter after a line of code does not autoindent. Instead the cursor always returns to column 0. With this change literate mode will pick up the autoindenting of the embedded language. Therefore hitting Enter after a line of code in a code block will autoindent as the user expects.